### PR TITLE
Provide way to reset simulator

### DIFF
--- a/launch/morse.launch
+++ b/launch/morse.launch
@@ -1,9 +1,6 @@
 <launch>
     <param name="/use_sim_time" value="true" />
-    <rosparam command="load" file="$(find iarc7_simulator)/param/morse.yaml" />
 
     <node name="morse_launcher" pkg="iarc7_simulator" type="morse_launcher.sh"
-        cwd="node" />
-
-    <node name="simulator_adapter" pkg="iarc7_simulator" type="simulator_adapter.py" />
+        cwd="node"/>
 </launch>

--- a/launch/morse.launch
+++ b/launch/morse.launch
@@ -1,5 +1,6 @@
 <launch>
     <param name="/use_sim_time" value="true" />
+    <rosparam command="load" file="$(find iarc7_simulator)/param/morse.yaml" />
 
     <node name="morse_launcher" pkg="iarc7_simulator" type="morse_launcher.sh"
         cwd="node"/>

--- a/launch/morse.launch
+++ b/launch/morse.launch
@@ -1,11 +1,11 @@
 <launch>
     <param name="/use_sim_time" value="true" />
     <rosparam command="load" file="$(find iarc7_simulator)/param/morse.yaml" />
-    
+
     <include file="$(find iarc7_simulator)/launch/static_transforms_sim.launch" />
 
-    <node name="morse_launcher" pkg="iarc7_simulator" type="morse_launcher.sh"
-        cwd="node" />
+    <node name="$(anon morse_launcher)" pkg="iarc7_simulator"
+        type="morse_launcher.sh" cwd="node" />
 
     <node name="simulator_adapter" pkg="iarc7_simulator" type="simulator_adapter.py" />
 </launch>

--- a/launch/morse.launch
+++ b/launch/morse.launch
@@ -1,7 +1,11 @@
 <launch>
     <param name="/use_sim_time" value="true" />
     <rosparam command="load" file="$(find iarc7_simulator)/param/morse.yaml" />
+    
+    <include file="$(find iarc7_simulator)/launch/static_transforms_sim.launch" />
 
     <node name="morse_launcher" pkg="iarc7_simulator" type="morse_launcher.sh"
-        cwd="node"/>
+        cwd="node" />
+
+    <node name="simulator_adapter" pkg="iarc7_simulator" type="simulator_adapter.py" />
 </launch>

--- a/launch/simulator_adapter.launch
+++ b/launch/simulator_adapter.launch
@@ -1,6 +1,0 @@
-<launch>
-    <param name="/use_sim_time" value="true" />
-    <rosparam command="load" file="$(find iarc7_simulator)/param/morse.yaml" />
-
-    <node name="simulator_adapter" pkg="iarc7_simulator" type="simulator_adapter.py" />
-</launch>

--- a/launch/simulator_adapter.launch
+++ b/launch/simulator_adapter.launch
@@ -1,0 +1,6 @@
+<launch>
+    <param name="/use_sim_time" value="true" />
+    <rosparam command="load" file="$(find iarc7_simulator)/param/morse.yaml" />
+
+    <node name="simulator_adapter" pkg="iarc7_simulator" type="simulator_adapter.py" />
+</launch>

--- a/scripts/morse_launcher.sh
+++ b/scripts/morse_launcher.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
-cd ../sim
-morse run sim 2> /tmp/morse.log
+
+PROCESS="blender"
+RESULT=`pgrep ${PROCESS}`
+
+if [ "${RESULT:-null}" = null ]; then
+    cd ../sim
+    morse run sim 2> /tmp/morse.log
+fi

--- a/scripts/morse_launcher.sh
+++ b/scripts/morse_launcher.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
-PROCESS="blender"
-RESULT=`pgrep ${PROCESS}`
-
-if [ "${RESULT:-null}" = null ]; then
+lockdir=/tmp/morse_launcher.sh.lock
+if mkdir $lockdir 2> /dev/null; then
+    trap "rmdir $lockdir" EXIT INT KILL TERM
     cd ../sim
     morse run sim 2> /tmp/morse.log
+else
+    echo "Failed to create lock directory at /tmp/morse_launcher.sh.lock, exiting..."
 fi

--- a/scripts/morse_launcher.sh
+++ b/scripts/morse_launcher.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 cd ../sim
-morse run sim
+morse run sim 2> /tmp/morse.log

--- a/scripts/reset_sim.py
+++ b/scripts/reset_sim.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+import pymorse
+
+with pymorse.Morse() as simu:
+    simu.reset()


### PR DESCRIPTION
When developing there is no need to relaunch the simulator every time something needs to be tested. This allows the simulator to be reset quickly to initial conditions.

Includes stderr piping from the other PR which I will close in a second.