### PR TITLE
Made /sim/quad/odom sensor publish transform to sim/quad/odom frame i…

### DIFF
--- a/sim/src/sim/builder/robots/Quadcopter.py
+++ b/sim/src/sim/builder/robots/Quadcopter.py
@@ -53,7 +53,7 @@ class Quadcopter(Robot):
         self.odom.add_stream('ros',
                              topic='/sim/quad/odom',
                              frame_id='map',
-                             child_frame_id='level_quad')
+                             child_frame_id='sim/quad/odom')
         self.append(self.odom)
 
         self.pose = Pose()

--- a/src/simulator_adapter.py
+++ b/src/simulator_adapter.py
@@ -37,6 +37,7 @@ def sim_odom_callback(odom_msg):
     odom_msg.pose.pose.orientation = Quaternion()
     odom_msg.pose.pose.orientation.w = 1.0
     odom_msg.twist.twist.angular = Vector3()
+    odom_msg.child_frame_id = 'level_quad'
     odom_pub.publish(odom_msg)
 
 def sim_pose_callback(pose_msg):


### PR DESCRIPTION
…nstead of level_quad

This fixed an issue where the simulator would publish the `map->level_quad` transform even when ground truth localization was turned off.