### PR TITLE
Fixed race condition for ground truth roombas

### DIFF
--- a/param/morse.yaml
+++ b/param/morse.yaml
@@ -11,6 +11,9 @@ sim:
     max_roomba_output_freq: 61
     max_obstacle_output_freq: 61
 
+    num_roombas: 10
+    num_obstacles: 4
+
     # Choose one of:
     #   MatteFloor
     #   SharperMatteFloor

--- a/src/simulator_adapter.py
+++ b/src/simulator_adapter.py
@@ -213,6 +213,8 @@ if __name__ == '__main__':
             '/sim/max_roomba_output_freq', float('Inf'))
     max_obstacle_output_freq = rospy.get_param(
             '/sim/max_obstacle_output_freq', float('Inf'))
+    num_roombas = rospy.get_param('/sim/num_roombas', 0)
+    num_obstacles = rospy.get_param('/sim/num_obstacles', 0)
 
     # MORSE SIDE COMMUNICATION
 
@@ -234,19 +236,17 @@ if __name__ == '__main__':
                                       Float64,
                                       queue_size=0)
     if publish_ground_truth_roombas:
-        for topic, _ in rospy.get_published_topics():
-            if re.match('/sim/roomba[0-9]*/odom', topic):
-                rospy.Subscriber(topic,
-                                 Odometry,
-                                 roomba_odom_callback,
-                                 (topic))
+        for i in range(num_roombas):
+            rospy.Subscriber('/sim/roomba{}/odom'.format(i),
+                             Odometry,
+                             roomba_odom_callback,
+                             ('/sim/roomba{}/odom'.format(i),))
     if publish_ground_truth_obstacles:
-        for topic, _ in rospy.get_published_topics():
-            if re.match('/sim/obstacle[0-9]*/odom', topic):
-                rospy.Subscriber(topic,
-                                 Odometry,
-                                 obstacle_odom_callback,
-                                 (topic))
+        for i in range(num_obstacles):
+            rospy.Subscriber('/sim/obstacle{}/odom'.format(i),
+                             Odometry,
+                             obstacle_odom_callback,
+                             ('/sim/obstacle{}/odom'.format(i),))
 
     # PUBLIC SIDE COMMUNICATION
 


### PR DESCRIPTION
Previously, if the simulator_adapter came up before the roombas were
available from the sim, they would not be published.  Now the roombas to
look for are passed through rosparam, so this isn't a problem.