### PR TITLE
Fixed wrong roomba locations

### DIFF
--- a/sim/src/sim/builder/robots/Roomba.py
+++ b/sim/src/sim/builder/robots/Roomba.py
@@ -1,6 +1,7 @@
 import math
 from morse.builder import *
 from sim.builder.sensors.BumpSensor import BumpSensor
+from sim.builder.sensors.OdometryAbsolutePose import OdometryAbsolutePose
 
 class Roomba(GroundRobot):
     """
@@ -43,9 +44,9 @@ class Roomba(GroundRobot):
         # Sensors
         ###################################
 
-        self.odom = Odometry()
-        self.odom.level('integrated')
+        self.odom = OdometryAbsolutePose()
         self.odom.add_stream('ros',
+                             'morse.middleware.ros.odometry.OdometryPublisher',
                              topic='/sim/{}/odom'.format(name),
                              frame_id='map',
                              child_frame_id='{}/base_link'.format(name))

--- a/sim/src/sim/builder/sensors/OdometryAbsolutePose.py
+++ b/sim/src/sim/builder/sensors/OdometryAbsolutePose.py
@@ -1,0 +1,7 @@
+from morse.builder import Odometry
+
+class OdometryAbsolutePose(Odometry):
+    _classpath = "sim.sensors.OdometryAbsolutePose.OdometryAbsolutePose"
+
+    def __init__(self, name=None):
+        Odometry.__init__(self, name)

--- a/sim/src/sim/builder/sensors/__init__.py
+++ b/sim/src/sim/builder/sensors/__init__.py
@@ -2,3 +2,4 @@ from .TopTouchSensor import TopTouchSensor
 from .BumpSensor import BumpSensor
 from .ContactSwitch import ContactSwitch
 from .LidarLite import LidarLite
+from .OdometryAbsolutePose import OdometryAbsolutePose

--- a/sim/src/sim/sensors/OdometryAbsolutePose.py
+++ b/sim/src/sim/sensors/OdometryAbsolutePose.py
@@ -1,0 +1,21 @@
+import logging; logger = logging.getLogger("morse." + __name__)
+
+import morse.core.sensor
+
+from morse.core.services import service, async_service
+from morse.core import status
+from morse.helpers.components import add_data, add_property
+
+from morse.sensors.odometry import IntegratedOdometry
+
+class OdometryAbsolutePose(IntegratedOdometry):
+    _name = "OdometryAbsolutePose"
+
+    def __init__(self, obj, parent=None):
+        logger.info("%s initialization" % obj.name)
+        IntegratedOdometry.__init__(self, obj, parent)
+
+        self.original_pos = morse.helpers.transformation.Transformation3d(None)
+        self.previous_pos = self.original_pos.transformation3d_with(self.position_3d)
+
+        logger.info('Component initialized')


### PR DESCRIPTION
Roomba locations were previously being published relative to their
starting locations, because this is the behavior of MORSE's builtin
odometry sensor.  This adds a new OdometryAbsolutePose sensor which
publishes everything relative to the origin of the map frame.

This should probably be tested on someone else's computer before it is merged to confirm that it works on an unmodified MORSE installation.