### PR TITLE
Ground truth roombas on by default

### DIFF
--- a/param/morse.yaml
+++ b/param/morse.yaml
@@ -3,7 +3,7 @@ sim:
     ground_truth_localization: false
     ground_truth_altitude: false
     ground_truth_camera_localization: false
-    ground_truth_roombas: false
+    ground_truth_roombas: true
     ground_truth_obstacles: false
 
     # Because MORSE spits out messages all at the same time, if you want these


### PR DESCRIPTION
Motion requires that roombas always be published. Since vision doesn't include the code to find the roombas yet this should be turned on.